### PR TITLE
Fix Framing Issues

### DIFF
--- a/Interfaces/ButtonHandler.cs
+++ b/Interfaces/ButtonHandler.cs
@@ -13,7 +13,9 @@
         public static Asset<Texture2D> Button_Happiness;
 
         public static Asset<Texture2D> Shop;
+        public static Rectangle ShopFrame;
         public static Asset<Texture2D> Extra;
+        public static Rectangle ExtraFrame;
 
         public static readonly Color BorderColor = Color.Black;
         public static readonly Color BackgroundColor = new Color(73, 85, 186);
@@ -52,7 +54,7 @@
             int buttonWidth = 375 / buttonCounts - spacing; // 每个按钮的宽度，+2是加上，-10是去除了按钮之间的间隔
 
             // 决定图标
-            ChatMethods.HandleButtonIcon(type, ref Shop, ref Extra);
+            ChatMethods.HandleButtonIcon(type, ref Shop, ref ShopFrame, ref Extra, ref ExtraFrame);
 
             int offsetX = 0;
 
@@ -76,17 +78,17 @@
 
         private static void DrawBackButton(float statY, bool longer) {
             Rectangle buttonRectangle = new Rectangle((int)ChatUI.PanelPosition.X + 16, (int)statY + 10, longer ? 98 : 44, 44);
-            Rectangle? frame = null;
             var value = Button_Back.Value;
+            Rectangle frame = value.Frame();
             // ModCall
             int type = Main.LocalPlayer.sign != -1 ? -1 : Main.npc[Main.LocalPlayer.talkNPC].type; // 为了标牌特判
             foreach (var info in from a in HandleAssets.IconInfos where a.npcTypes.Contains(type) && a.available() && a.texture != "" && a.iconType == IconType.Back select a) {
                 value = ModContent.Request<Texture2D>(info.texture).Value;
-                frame = info.frame();
+                frame = info.frame?.Invoke() ?? value.Frame();
             }
 
             DrawPanel(SpriteBatch, ButtonPanel.Value, buttonRectangle.Location.ToVector2(), buttonRectangle.Size(), Color.White);
-            SpriteBatch.Draw(value, buttonRectangle.Location.ToVector2() + buttonRectangle.Size() / 2f, frame, Color.White * 0.9f, 0f, Button_Back.Size() / 2f, 1f, SpriteEffects.None, 0f);
+            SpriteBatch.Draw(value, buttonRectangle.Location.ToVector2() + buttonRectangle.Size() / 2f, frame, Color.White * 0.9f, 0f, frame.Size() / 2f, 1f, SpriteEffects.None, 0f);
 
             if (buttonRectangle.Contains(new Point(MouseX, MouseY))) {
                 if (!moveOnBackButton) {
@@ -112,13 +114,13 @@
 
         private static void DrawHappinessButton(float statY) {
             Vector2 pos = new Vector2(ChatUI.PanelPosition.X + 68, statY + 10);
-            Rectangle? frame = null;
             var value = Button_Happiness.Value;
+            Rectangle frame = value.Frame();
             // ModCall
             int type = Main.LocalPlayer.sign != -1 ? -1 : Main.npc[Main.LocalPlayer.talkNPC].type; // 为了标牌特判
             foreach (var info in from a in HandleAssets.IconInfos where a.npcTypes.Contains(type) && a.available() && a.texture != "" && a.iconType == IconType.Happiness select a) {
                 value = ModContent.Request<Texture2D>(info.texture).Value;
-                frame = info.frame();
+                frame = info.frame?.Invoke() ?? value.Frame();
             }
 
             DrawPanel(SpriteBatch, ButtonPanel.Value, pos, new Vector2(44, 44), Color.White);
@@ -172,7 +174,7 @@
             // 按钮
             DrawPanel(SpriteBatch, ButtonPanel.Value, pos, new Vector2(width, height), Color.White);
             // 对应图像（即icon）
-            SpriteBatch.Draw(Shop.Value, pos + new Vector2(44, height) / 2f, null, Color.White * 0.9f, 0f, new Vector2(Shop.Width(), Shop.Height()) / 2f, 1f, SpriteEffects.None, 0f);
+            SpriteBatch.Draw(Shop.Value, pos + new Vector2(44, height) / 2f, ShopFrame, Color.White * 0.9f, 0f, ShopFrame.Size() / 2f, 1f, SpriteEffects.None, 0f);
             Rectangle buttonRectangle = new Rectangle((int)pos.X, (int)pos.Y, width, height);
             if (buttonRectangle.Contains(new Point(MouseX, MouseY))) {
                 if (!moveOnShopButton) {
@@ -226,7 +228,7 @@
             // 按钮
             DrawPanel(SpriteBatch, ButtonPanel.Value, pos, new Vector2(width, height), Color.White);
             // 对应图像（即icon）
-            SpriteBatch.Draw(Extra.Value, pos + new Vector2(44, height) / 2f, null, Color.White * 0.9f, 0f, new Vector2(Extra.Width(), Extra.Height()) / 2f, 1f, SpriteEffects.None, 0f);
+            SpriteBatch.Draw(Extra.Value, pos + new Vector2(44, height) / 2f, ExtraFrame, Color.White * 0.9f, 0f, ExtraFrame.Size() / 2f, 1f, SpriteEffects.None, 0f);
             Rectangle buttonRectangle = new Rectangle((int)pos.X, (int)pos.Y, width, height);
             if (buttonRectangle.Contains(new Point(MouseX, MouseY))) {
                 NPC talkNPC = Main.npc[Main.LocalPlayer.talkNPC];

--- a/Interfaces/ChatMethods.cs
+++ b/Interfaces/ChatMethods.cs
@@ -98,20 +98,26 @@ namespace DialogueTweak.Interfaces
         }
 
         // 自己写的控制Shop和Extra的贴图
-        public static void HandleButtonIcon(int i, ref Asset<Texture2D> Shop, ref Asset<Texture2D> Extra) {
+        public static void HandleButtonIcon(int i, ref Asset<Texture2D> Shop, ref Rectangle ShopFrame, ref Asset<Texture2D> Extra, ref Rectangle ExtraFrame) {
             // -1即标牌绘制
             if (i == -1) {
                 Shop = HandleAssets.EditIcon;
+                ShopFrame = Shop.Frame();
                 foreach (var info in from a in HandleAssets.IconInfos where a.npcTypes.Contains(-1) && a.available() && a.texture != "" && a.texture != "Head" select a) {
                     if (info.iconType == IconType.Shop) {
                         Shop = ModContent.Request<Texture2D>(info.texture);
+                        ShopFrame = info.frame?.Invoke() ?? Shop.Frame();
                     }
                     if (info.iconType == IconType.Extra) {
                         Extra = ModContent.Request<Texture2D>(info.texture);
+                        ExtraFrame = info.frame?.Invoke() ?? Extra.Frame();
                     }
                 }
                 return;
             }
+
+            Rectangle? shopFrameOverride = null;
+            Rectangle? extraFrameOverride = null;
 
             var npc = Main.npc[Main.LocalPlayer.talkNPC];
             int type = npc.type;
@@ -137,6 +143,7 @@ namespace DialogueTweak.Interfaces
                     }
                     else {
                         Shop = ModContent.Request<Texture2D>(info.texture);
+                        shopFrameOverride = info.frame?.Invoke();
                     }
                 }
                 if (info.iconType == IconType.Extra) {
@@ -145,9 +152,13 @@ namespace DialogueTweak.Interfaces
                     }
                     else {
                         Extra = ModContent.Request<Texture2D>(info.texture);
+                        extraFrameOverride = info.frame?.Invoke();
                     }
                 }
             }
+
+            ShopFrame = shopFrameOverride ?? Shop.Frame();
+            ExtraFrame = extraFrameOverride ?? Extra.Frame();
         }
 
         // 根据标牌type获取对应物品type，原版是直接NewItem所以这里只能特判了

--- a/Interfaces/PortraitDrawer.cs
+++ b/Interfaces/PortraitDrawer.cs
@@ -44,7 +44,7 @@
             foreach (var info in from a in HandleAssets.IconInfos where a.npcTypes.Contains(talkNPC.type) && a.available() && a.texture != "" && a.iconType == IconType.Portrait select a) {
                 if (info.texture == "None") return;
                 value = ModContent.Request<Texture2D>(info.texture).Value;
-                frame = (info.frame ?? (() => new Rectangle(0, 0, value.Width, value.Height)))(); // 如果info.frame为null则使用new Rectangle(0, 0, value.Width, value.Height)
+                frame = info.frame?.Invoke() ?? value.Frame(); // 如果info.frame为null则使用new Rectangle(0, 0, value.Width, value.Height)
             }
 
             var position = panel.Location.ToVector2() + new Vector2(62f, 62f);
@@ -78,7 +78,7 @@
 
             // 画像
             var value = HandleAssets.SignIcon.Value;
-            Rectangle? frame = null;
+            Rectangle frame = value.Frame();
             bool useItemTexture = true;
             int i = Main.LocalPlayer.sign;
             if (Main.sign[i] is null || !WorldGen.InWorld(Main.sign[i].x, Main.sign[i].y) || !Main.tile[Main.sign[i].x, Main.sign[i].y].HasTile)
@@ -92,7 +92,7 @@
             foreach (var info in from a in HandleAssets.IconInfos where a.npcTypes.Contains(-1) && a.available() && a.texture != "" && a.iconType == IconType.Portrait select a) {
                 if (info.texture == "None") return;
                 value = ModContent.Request<Texture2D>(info.texture).Value;
-                frame = info.frame();
+                frame = info.frame?.Invoke() ?? value.Frame();
                 useItemTexture = false;
             }
 
@@ -105,6 +105,7 @@
                 if (dropItem < TextureAssets.Item.Length && TextureAssets.Item[dropItem] is not null) {
                     Main.instance.LoadItem(dropItem);
                     value = TextureAssets.Item[dropItem].Value;
+                    frame = value.Frame();
                     var item = new Item();
                     item.netDefaults(dropItem);
                     text = item.Name;
@@ -117,7 +118,7 @@
             sb.End();
             sb.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, Main.DefaultSamplerState, null, null, null, Main.UIScaleMatrix);
 
-            sb.Draw(value, position, frame, Color.White, 0f, value.Size() / 2f, 2f, SpriteEffects.None, 0f);
+            sb.Draw(value, position, frame, Color.White, 0f, frame.Size() / 2f, 2f, SpriteEffects.None, 0f);
 
             // 还原
             sb.End();


### PR DESCRIPTION
* Fixed custom Shop and Extra icon frames not being applied.
* Many icons are now centered on their frame rather than their texture.
* All icon frames are now `Rectangle` instead of `Rectangle?` and safely retrieve their frame.

Before:
![Screenshot_1006_dotnet](https://user-images.githubusercontent.com/33076411/232180034-3cc99f0d-8646-487f-b2a5-b195d8b56329.png)
After:
![Screenshot_1007_dotnet](https://user-images.githubusercontent.com/33076411/232180037-114ad2db-8a05-4720-9f18-7aef305f414e.png)