### PR TITLE
Fix Signs

### DIFF
--- a/Interfaces/ChatMethods.cs
+++ b/Interfaces/ChatMethods.cs
@@ -140,7 +140,7 @@ public static class ChatMethods
             }
 
             shopFrame = shopFrameOverride ?? shop.Frame();
-            extraFrame = extraFrameOverride ?? extra.Frame();
+            extraFrame = extraFrameOverride ?? extra?.Frame() ?? default;
             return;
         }
 


### PR DESCRIPTION
Fix signs throwing `NullReferenceException`s because they had no associated extra texture (despite not using one) and breaking UI.